### PR TITLE
chore: add pkgbuild/generate.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,8 @@
 pnpm i
 pnpm dev
 
-# build
+# build (see misc/pkgbuild/README.md for installation on archlinux)
 pnpm build
-ls -lh src-tauri/target/release/bundle/*/*.{AppImage,deb}
-# -rwxr-xr-x 1 hiroshi hiroshi 147M Jan 16 13:22 src-tauri/target/release/bundle/appimage/tauri-vite-example_0.1.0_amd64.AppImage
-# -rw-r--r-- 1 hiroshi hiroshi 3.4M Jan 16 13:21 src-tauri/target/release/bundle/deb/tauri-vite-example_0.1.0_amd64.deb
 chmod +x src-tauri/target/release/bundle/appimage/tauri-vite-example_0.1.0_amd64.AppImage
 ./src-tauri/target/release/bundle/appimage/tauri-vite-example_0.1.0_amd64.AppImage
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tauri vite example
 
-tauri port of https://github.com/hi-ogawa/electron-vite-experiment
+[tauri](https://github.com/tauri-apps/tauri) port of https://github.com/hi-ogawa/electron-vite-experiment
 
 ```sh
 # development

--- a/misc/pkgbuild/README.md
+++ b/misc/pkgbuild/README.md
@@ -2,7 +2,7 @@
 
 ```sh
 # build deb file
-pnpm build --bundle deb
+pnpm build --bundles deb
 
 # generate PKGBUILD file based on deb file
 bash misc/pkgbuild/generate.sh

--- a/misc/pkgbuild/README.md
+++ b/misc/pkgbuild/README.md
@@ -1,0 +1,12 @@
+# PKGBUILD
+
+```sh
+# build deb file
+pnpm build --bundle deb
+
+# generate PKGBUILD file based on deb file
+bash misc/pkgbuild/generate.sh
+
+# install locally
+(cd misc/pkgbuild/build && makepkg -si)
+```

--- a/misc/pkgbuild/generate.sh
+++ b/misc/pkgbuild/generate.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -eu -o pipefail
+
+#
+# based on the output of
+#   debtap -P src-tauri/target/release/bundle/deb/tauri-vite-example_0.1.0_amd64.deb
+#
+# see also https://github.com/tauri-apps/tauri/pull/4301
+#
+
+conf_json="src-tauri/tauri.conf.json"
+bundle_dir="src-tauri/target/release/bundle"
+build_dir="misc/pkgbuild/build"
+
+# extract package attributes
+productName="$(jq -r '.package.productName' < "$conf_json")"
+pkgver="$(jq -r '.package.version' < "$conf_json")"
+pkgdesc="$(jq -r '.tauri.bundle.longDescription' < "$conf_json")"
+
+# copy deb file locally
+deb_path="$bundle_dir/deb/${productName}_${pkgver}_amd64.deb"
+deb_basename="$(basename "$deb_path")"
+mkdir -p "$build_dir"
+cp -f "$deb_path" "$build_dir/$deb_basename"
+
+# emit PKGBUILD
+cat > "$build_dir/PKGBUILD" <<EOF
+pkgname="$productName-bin"
+pkgver="$pkgver"
+pkgrel=1
+pkgdesc="$pkgdesc"
+arch=('x86_64')
+url=""
+license=('')
+depends=('gtk3' 'webkit2gtk')
+source=("$deb_basename")
+sha512sums=("SKIP")
+
+package(){
+  tar -xz -f data.tar.gz -C "\${pkgdir}"
+}
+EOF


### PR DESCRIPTION
- cf. https://github.com/tauri-apps/tauri/pull/4301

## notes

- this is mostly for quick local installation
- `source` can be a url to released `deb` url if it's published separately
- `depends` might want to also include `libappindicator-gtk3`
  - https://github.com/tauri-apps/wry/#platform-specific-notes

## generated `PKGFILE`

```sh
pkgname="tauri-vite-example-bin"
pkgver="0.1.0"
pkgrel=1
pkgdesc=""
arch=('x86_64')
url=""
license=('')
depends=('gtk3' 'webkit2gtk')
source=("tauri-vite-example_0.1.0_amd64.deb")
sha512sums=("SKIP")

package(){
  tar -xz -f data.tar.gz -C "${pkgdir}"
}
```